### PR TITLE
refactor: Organize package.json dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@11ty/eleventy": "3.0.0",
-				"chalk": "4.1.2",
 				"clean-css": "5.3.3",
-				"concurrently": "9.1.2",
 				"cssnano": "7.0.7",
 				"postcss": "8.5.3",
 				"postcss-cli": "11.0.1",
@@ -24,6 +22,8 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "9.27.0",
+				"chalk": "4.1.2",
+				"concurrently": "9.1.2",
 				"eslint": "9.27.0",
 				"globals": "16.1.0",
 				"husky": "9.1.7",
@@ -1202,6 +1202,7 @@
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -1436,6 +1437,7 @@
 			"version": "9.1.2",
 			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.1.2.tgz",
 			"integrity": "sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chalk": "^4.1.2",
@@ -1459,6 +1461,7 @@
 		},
 		"node_modules/concurrently/node_modules/supports-color": {
 			"version": "8.1.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -2944,6 +2947,7 @@
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -3536,6 +3540,7 @@
 		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.memoize": {
@@ -5341,6 +5346,7 @@
 		},
 		"node_modules/rxjs": {
 			"version": "7.8.2",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.1.0"
@@ -5414,6 +5420,7 @@
 		},
 		"node_modules/shell-quote": {
 			"version": "1.8.2",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -5928,6 +5935,7 @@
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -6266,6 +6274,7 @@
 		},
 		"node_modules/tree-kill": {
 			"version": "1.2.2",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"tree-kill": "cli.js"
@@ -6277,6 +6286,7 @@
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
+			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -53,9 +53,7 @@
 	},
 	"dependencies": {
 		"@11ty/eleventy": "3.0.0",
-		"chalk": "4.1.2",
 		"clean-css": "5.3.3",
-		"concurrently": "9.1.2",
 		"cssnano": "7.0.7",
 		"postcss": "8.5.3",
 		"postcss-cli": "11.0.1",
@@ -67,6 +65,8 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "9.27.0",
+		"chalk": "4.1.2",
+		"concurrently": "9.1.2",
 		"eslint": "9.27.0",
 		"globals": "16.1.0",
 		"husky": "9.1.7",


### PR DESCRIPTION
Correctly classify dependencies into 'dependencies' and 'devDependencies' based on their role in the production build versus development workflow.