### PR TITLE
refactor: Use rimraf for cross-platform clean script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 				"markdownlint-cli2": "0.18.1",
 				"postcss-nesting": "13.0.1",
 				"prettier": "3.5.3",
+				"rimraf": "6.0.1",
 				"stylelint": "16.19.1",
 				"stylelint-config-recess-order": "6.0.0",
 				"stylelint-config-standard": "38.0.0",
@@ -223,6 +224,21 @@
 				"promise": "^7.0.1",
 				"rimraf": "^5.0.7",
 				"slash": "^1.0.0"
+			}
+		},
+		"node_modules/@11ty/recursive-copy/node_modules/rimraf": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@11ty/recursive-copy/node_modules/slash": {
@@ -5311,13 +5327,113 @@
 			"license": "MIT"
 		},
 		"node_modules/rimraf": {
-			"version": "5.0.10",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+			"integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"glob": "^10.3.7"
+				"glob": "^11.0.0",
+				"package-json-from-dist": "^1.0.0"
 			},
 			"bin": {
 				"rimraf": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+			"integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^4.0.1",
+				"minimatch": "^10.0.0",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^2.0.0"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/jackspeak": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+			"integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/lru-cache": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+			"integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+			"integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/path-scurry": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+			"integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"main": "",
 	"scripts": {
 		"build": "npm run clean && eleventy && NODE_ENV=production npm run css",
-		"clean": "rm -r -f dist && mkdir dist",
+		"clean": "rimraf dist && mkdir dist",
 		"css": "npx postcss src/css/*.css --dir dist/css",
 		"format": "prettier --write .",
 		"format:check": "prettier --check .",
@@ -74,6 +74,7 @@
 		"markdownlint-cli2": "0.18.1",
 		"postcss-nesting": "13.0.1",
 		"prettier": "3.5.3",
+		"rimraf": "6.0.1",
 		"stylelint": "16.19.1",
 		"stylelint-config-recess-order": "6.0.0",
 		"stylelint-config-standard": "38.0.0",


### PR DESCRIPTION
Replaced the platform-specific 'rm -r -f' command with 'rimraf' in the clean script. This ensures the script works correctly on Windows and other operating systems, improving project compatibility.