### PR TITLE
Revert "chore: Configure Prettier for Nunjucks files (#39)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
 				"markdownlint-cli2": "0.18.1",
 				"postcss-nesting": "13.0.1",
 				"prettier": "3.5.3",
-				"prettier-plugin-jinja-template": "2.1.0",
 				"rimraf": "6.0.1",
 				"stylelint": "16.19.1",
 				"stylelint-config-recess-order": "6.0.0",
@@ -5177,16 +5176,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"node_modules/prettier-plugin-jinja-template": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/prettier-plugin-jinja-template/-/prettier-plugin-jinja-template-2.1.0.tgz",
-			"integrity": "sha512-mzoCp2Oy9BDSug80fw3B3J4n4KQj1hRvoQOL1akqcDKBb5nvYxrik9zUEDs4AEJ6nK7QDTGoH0y9rx7AlnQ78Q==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"prettier": "^3.0.0"
 			}
 		},
 		"node_modules/pretty-hrtime": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
 		"markdownlint-cli2": "0.18.1",
 		"postcss-nesting": "13.0.1",
 		"prettier": "3.5.3",
-		"prettier-plugin-jinja-template": "2.1.0",
 		"rimraf": "6.0.1",
 		"stylelint": "16.19.1",
 		"stylelint-config-recess-order": "6.0.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -5,7 +5,6 @@
  * @type {import("prettier").Config}
  */
 const config = {
-	plugins: ["prettier-plugin-jinja-template"],
 	quoteProps: "consistent",
 	overrides: [
 		{
@@ -24,13 +23,6 @@ const config = {
 			files: ["*.jsonc"],
 			options: {
 				trailingComma: "none",
-			},
-		},
-		{
-			files: ["*.njk"],
-			options: {
-				parser: "jinja-template",
-				printWidth: 9999,
 			},
 		},
 	],


### PR DESCRIPTION
This reverts commit 944a702776557233c67bde3d504f5e2f3afee031.

Due to ongoing complexity and limitations with mixed content formatting.