### PR TITLE
fix: Correct Nunjucks HTML structural errors

### DIFF
--- a/src/pattern-library/all-patterns.njk
+++ b/src/pattern-library/all-patterns.njk
@@ -39,7 +39,7 @@ summary: 'A collection of every component and their variants as a cumulutive ref
                     <a href="{{ link.url }}">{{ link.label }}</a>
                   {% else %}
                     <dl>
-                      <dt>{{ link.label }}</dd>
+                      <dt>{{ link.label }}</dt>
                       <dd>
                         <code>{{ link.url }}</code>
                       </dd>

--- a/src/pattern-library/patterns.njk
+++ b/src/pattern-library/patterns.njk
@@ -45,7 +45,7 @@ permalink: '{{ item.url }}/index.html'
                 <a href="{{ link.url }}">{{ link.label }}</a>
               {% else %}
                 <dl>
-                  <dt>{{ link.label }}</dd>
+                  <dt>{{ link.label }}</dt>
                   <dd>
                     <code>{{ link.url }}</code>
                   </dd>

--- a/src/pattern-library/patterns/button/button.njk
+++ b/src/pattern-library/patterns/button/button.njk
@@ -1,13 +1,13 @@
 {% if data.href %}
   <a class="button" href="{{ data.href }}" {% if data.variant %}data-button-variant="{{ data.variant }}"{% endif %}>
-  {% else %}
-    <button class="button"  {% if data.variant %}data-button-variant="{{ data.variant }}"{% endif %}>
-    {% endif %}
     <span>{{ data.label }}</span>
     {% include "icons/arrow.svg" %}
     <span class="corner" aria-hidden="true"></span>
-    {% if data.href %}
-    </a>
-  {% else %}
+  </a>
+{% else %}
+  <button class="button" {% if data.variant %}data-button-variant="{{ data.variant }}"{% endif %}>
+    <span>{{ data.label }}</span>
+    {% include "icons/arrow.svg" %}
+    <span class="corner" aria-hidden="true"></span>
   </button>
 {% endif %}


### PR DESCRIPTION
Addresses multiple instances of incorrect HTML markup in Nunjucks templates, including:
- Mismatched `<a>` and `<button>` opening/closing tags in `button.njk`.
- Incorrect `</dd>` closing tags for `<dt>` elements in definition lists.

Ensures proper HTML nesting and resolves Prettier syntax errors.