### PR TITLE
refactor: Categorize build tools as devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,41 +8,39 @@
 			"name": "complete-css-course",
 			"version": "0.1.0",
 			"license": "MIT",
-			"dependencies": {
-				"@11ty/eleventy": "3.1.2",
-				"clean-css": "5.3.3",
-				"cssnano": "7.1.0",
-				"postcss": "8.5.3",
-				"postcss-cli": "11.0.1",
-				"postcss-import": "16.1.1",
-				"postcss-import-ext-glob": "2.1.1",
-				"postcss-js": "4.0.1",
-				"slugify": "1.6.6",
-				"tailwindcss": "3.3.5"
-			},
 			"devDependencies": {
+				"@11ty/eleventy": "3.1.2",
 				"@eslint/js": "9.31.0",
 				"chalk": "4.1.2",
+				"clean-css": "5.3.3",
 				"concurrently": "9.1.2",
+				"cssnano": "7.1.0",
 				"eslint": "9.31.0",
 				"globals": "16.3.0",
 				"husky": "9.1.7",
 				"lint-staged": "16.1.2",
 				"markdownlint-cli2": "0.18.1",
+				"postcss-cli": "11.0.1",
+				"postcss-import": "16.1.1",
+				"postcss-import-ext-glob": "2.1.1",
+				"postcss-js": "4.0.1",
 				"postcss-nesting": "13.0.2",
 				"prettier": "3.6.2",
 				"rimraf": "6.0.1",
+				"slugify": "1.6.6",
 				"stylelint": "16.19.1",
 				"stylelint-config-recess-order": "7.1.0",
 				"stylelint-config-standard": "38.0.0",
 				"stylelint-order": "7.0.0",
-				"stylelint-plugin-defensive-css": "1.0.4"
+				"stylelint-plugin-defensive-css": "1.0.4",
+				"tailwindcss": "3.3.5"
 			}
 		},
 		"node_modules/@11ty/dependency-tree": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@11ty/dependency-tree/-/dependency-tree-4.0.0.tgz",
 			"integrity": "sha512-PTOnwM8Xt+GdJmwRKg4pZ8EKAgGoK7pedZBfNSOChXu8MYk2FdEsxdJYecX4t62owpGw3xK60q9TQv/5JI59jw==",
+			"dev": true,
 			"dependencies": {
 				"@11ty/eleventy-utils": "^2.0.1"
 			}
@@ -51,6 +49,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@11ty/dependency-tree-esm/-/dependency-tree-esm-2.0.0.tgz",
 			"integrity": "sha512-+4ySOON4aEAiyAGuH6XQJtxpGSpo6nibfG01krgix00sqjhman2+UaDUopq6Ksv8/jBB3hqkhsHe3fDE4z8rbA==",
+			"dev": true,
 			"dependencies": {
 				"@11ty/eleventy-utils": "^2.0.1",
 				"acorn": "^8.14.0",
@@ -62,6 +61,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-3.1.2.tgz",
 			"integrity": "sha512-IcsDlbXnBf8cHzbM1YBv3JcTyLB35EK88QexmVyFdVJVgUU6bh9g687rpxryJirHzo06PuwnYaEEdVZQfIgRGg==",
+			"dev": true,
 			"dependencies": {
 				"@11ty/dependency-tree": "^4.0.0",
 				"@11ty/dependency-tree-esm": "^2.0.0",
@@ -110,6 +110,7 @@
 		},
 		"node_modules/@11ty/eleventy-dev-server": {
 			"version": "2.0.8",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@11ty/eleventy-utils": "^2.0.1",
@@ -140,6 +141,7 @@
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-bundle/-/eleventy-plugin-bundle-3.0.6.tgz",
 			"integrity": "sha512-wlEIMa1SEe6HE6ZyREEnPQiTw72337a2MPkyn0D1IzrqHrKU9euB17mv27LnnnyKvMJamCCqtU0985F5yyDL8g==",
+			"dev": true,
 			"dependencies": {
 				"@11ty/eleventy-utils": "^2.0.2",
 				"debug": "^4.4.0",
@@ -157,6 +159,7 @@
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-2.0.7.tgz",
 			"integrity": "sha512-6QE+duqSQ0GY9rENXYb4iPR4AYGdrFpqnmi59tFp9VrleOl0QSh8VlBr2yd6dlhkdtj7904poZW5PvGr9cMiJQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -169,6 +172,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
 			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -180,6 +184,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -189,6 +194,7 @@
 		},
 		"node_modules/@11ty/lodash-custom": {
 			"version": "4.17.21",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
@@ -200,6 +206,7 @@
 		},
 		"node_modules/@11ty/posthtml-urls": {
 			"version": "1.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"evaluate-value": "^2.0.0",
@@ -215,6 +222,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@11ty/recursive-copy/-/recursive-copy-4.0.2.tgz",
 			"integrity": "sha512-174nFXxL/6KcYbLYpra+q3nDbfKxLxRTNVY1atq2M1pYYiPfHse++3IFNl8mjPFsd7y2qQjxLORzIjHMjL3NDQ==",
+			"dev": true,
 			"dependencies": {
 				"errno": "^1.0.0",
 				"junk": "^3.1.0",
@@ -229,12 +237,14 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
 			"version": "5.2.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -580,6 +590,7 @@
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^5.1.2",
@@ -595,6 +606,7 @@
 		},
 		"node_modules/@isaacs/cliui/node_modules/ansi-styles": {
 			"version": "6.2.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -605,10 +617,12 @@
 		},
 		"node_modules/@isaacs/cliui/node_modules/emoji-regex": {
 			"version": "9.2.2",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@isaacs/cliui/node_modules/string-width": {
 			"version": "5.1.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"eastasianwidth": "^0.2.0",
@@ -624,6 +638,7 @@
 		},
 		"node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
 			"version": "8.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^6.1.0",
@@ -639,6 +654,7 @@
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.8",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
@@ -651,6 +667,7 @@
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -658,6 +675,7 @@
 		},
 		"node_modules/@jridgewell/set-array": {
 			"version": "1.2.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -665,10 +683,12 @@
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -687,6 +707,7 @@
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -698,6 +719,7 @@
 		},
 		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -705,6 +727,7 @@
 		},
 		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -716,6 +739,7 @@
 		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"engines": {
@@ -737,6 +761,7 @@
 		},
 		"node_modules/@sindresorhus/slugify": {
 			"version": "2.2.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/transliterate": "^1.0.0",
@@ -751,6 +776,7 @@
 		},
 		"node_modules/@sindresorhus/slugify/node_modules/escape-string-regexp": {
 			"version": "5.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -761,6 +787,7 @@
 		},
 		"node_modules/@sindresorhus/transliterate": {
 			"version": "1.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"escape-string-regexp": "^5.0.0"
@@ -774,6 +801,7 @@
 		},
 		"node_modules/@sindresorhus/transliterate/node_modules/escape-string-regexp": {
 			"version": "5.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -827,12 +855,14 @@
 		},
 		"node_modules/a-sync-waterfall": {
 			"version": "1.0.1",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -851,6 +881,7 @@
 		},
 		"node_modules/acorn-walk": {
 			"version": "8.3.4",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.11.0"
@@ -892,6 +923,7 @@
 		},
 		"node_modules/ansi-regex": {
 			"version": "6.1.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -902,6 +934,7 @@
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -915,10 +948,12 @@
 		},
 		"node_modules/any-promise": {
 			"version": "1.3.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"normalize-path": "^3.0.0",
@@ -930,16 +965,19 @@
 		},
 		"node_modules/arg": {
 			"version": "5.0.2",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "Python-2.0"
 		},
 		"node_modules/array-differ": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
 			"integrity": "sha512-LeZY+DZDRnvP7eMuQ6LHfCzUGxAAIViUBliK24P3hWXL6y4SortgR6Nim6xrkfSLlmH0+k+9NYNwVC2s53ZrYQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -956,6 +994,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
 			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -964,12 +1003,14 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
 			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/asap": {
 			"version": "2.0.6",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/astral-regex": {
@@ -982,6 +1023,7 @@
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/base64-js": {
@@ -1007,6 +1049,7 @@
 		},
 		"node_modules/bcp-47": {
 			"version": "2.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-alphabetical": "^2.0.0",
@@ -1020,6 +1063,7 @@
 		},
 		"node_modules/bcp-47-match": {
 			"version": "2.0.3",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -1028,6 +1072,7 @@
 		},
 		"node_modules/bcp-47-normalize": {
 			"version": "2.3.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bcp-47": "^2.0.0",
@@ -1040,6 +1085,7 @@
 		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -1052,12 +1098,14 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
 			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -1066,6 +1114,7 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -1078,6 +1127,7 @@
 			"version": "4.25.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
 			"integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1162,6 +1212,7 @@
 		},
 		"node_modules/camelcase-css": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -1171,6 +1222,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
 			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.0.0",
@@ -1183,6 +1235,7 @@
 			"version": "1.0.30001727",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
 			"integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -1249,6 +1302,7 @@
 		},
 		"node_modules/chokidar": {
 			"version": "3.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.2",
@@ -1271,6 +1325,7 @@
 		},
 		"node_modules/chokidar/node_modules/glob-parent": {
 			"version": "5.1.2",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -1283,6 +1338,7 @@
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
 			"integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"source-map": "~0.6.0"
@@ -1326,6 +1382,7 @@
 		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -1338,6 +1395,7 @@
 		},
 		"node_modules/cliui/node_modules/ansi-regex": {
 			"version": "5.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -1345,10 +1403,12 @@
 		},
 		"node_modules/cliui/node_modules/emoji-regex": {
 			"version": "8.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/cliui/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -1356,6 +1416,7 @@
 		},
 		"node_modules/cliui/node_modules/string-width": {
 			"version": "4.2.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -1368,6 +1429,7 @@
 		},
 		"node_modules/cliui/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -1378,6 +1440,7 @@
 		},
 		"node_modules/cliui/node_modules/wrap-ansi": {
 			"version": "7.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -1393,6 +1456,7 @@
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -1403,10 +1467,12 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.4",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/colord": {
 			"version": "2.9.3",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/colorette": {
@@ -1427,6 +1493,7 @@
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/concurrently": {
@@ -1496,6 +1563,7 @@
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -1510,6 +1578,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
 			"integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14 || ^16 || >=18"
@@ -1530,6 +1599,7 @@
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
 			"integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boolbase": "^1.0.0",
@@ -1544,6 +1614,7 @@
 		},
 		"node_modules/css-tree": {
 			"version": "3.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.12.2",
@@ -1557,6 +1628,7 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
 			"integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">= 6"
@@ -1567,6 +1639,7 @@
 		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
@@ -1579,6 +1652,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.0.tgz",
 			"integrity": "sha512-Pu3rlKkd0ZtlCUzBrKL1Z4YmhKppjC1H9jo7u1o4qaKqyhvixFgu5qLyNIAOjSTg9DjVPtUqdROq2EfpVMEe+w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssnano-preset-default": "^7.0.8",
@@ -1599,6 +1673,7 @@
 			"version": "7.0.8",
 			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.8.tgz",
 			"integrity": "sha512-d+3R2qwrUV3g4LEMOjnndognKirBZISylDZAF/TPeCWVjEwlXS2e4eN4ICkoobRe7pD3H6lltinKVyS1AJhdjQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.25.1",
@@ -1643,6 +1718,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.1.tgz",
 			"integrity": "sha512-ZIP71eQgG9JwjVZsTPSqhc6GHgEr53uJ7tK5///VfyWj6Xp2DBmixWHqJgPno+PqATzn48pL42ww9x5SSGmhZg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -1655,6 +1731,7 @@
 			"version": "5.0.5",
 			"resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
 			"integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"css-tree": "~2.2.0"
@@ -1668,6 +1745,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
 			"integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.0.28",
@@ -1682,12 +1760,14 @@
 			"version": "2.0.28",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
 			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/debug": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
 			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dev": true,
 			"dependencies": {
 				"ms": "^2.1.3"
 			},
@@ -1721,6 +1801,7 @@
 		},
 		"node_modules/depd": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -1730,6 +1811,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
 			"integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -1761,6 +1843,7 @@
 		},
 		"node_modules/didyoumean": {
 			"version": "1.2.2",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/dir-glob": {
@@ -1784,12 +1867,14 @@
 		},
 		"node_modules/dlv": {
 			"version": "1.1.3",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
 			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"domelementtype": "^2.3.0",
@@ -1802,6 +1887,7 @@
 		},
 		"node_modules/domelementtype": {
 			"version": "2.3.0",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -1814,6 +1900,7 @@
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
 			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"domelementtype": "^2.3.0"
@@ -1829,6 +1916,7 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
 			"integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"dom-serializer": "^2.0.0",
@@ -1841,16 +1929,19 @@
 		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ee-first": {
 			"version": "1.1.1",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.189",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.189.tgz",
 			"integrity": "sha512-y9D1ntS1ruO/pZ/V2FtLE+JXLQe28XoRpZ7QCCo0T8LdQladzdcOVQZH/IWLVJvCw12OGMb6hYOeOAjntCmJRQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/emoji-regex": {
@@ -1862,6 +1953,7 @@
 		},
 		"node_modules/encodeurl": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -1869,6 +1961,7 @@
 		},
 		"node_modules/entities": {
 			"version": "4.5.0",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
@@ -1902,6 +1995,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-1.0.0.tgz",
 			"integrity": "sha512-3zV5mFS1E8/1bPxt/B0xxzI1snsg3uSCIh6Zo1qKg6iMw93hzPANk9oBFzSFBFrwuVoQuE3rLoouAUfwOAj1wQ==",
+			"dev": true,
 			"dependencies": {
 				"prr": "~1.0.1"
 			},
@@ -1919,6 +2013,7 @@
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -1926,6 +2021,7 @@
 		},
 		"node_modules/escape-html": {
 			"version": "1.0.3",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/escape-string-regexp": {
@@ -2032,6 +2128,7 @@
 		},
 		"node_modules/esm-import-transformer": {
 			"version": "3.0.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.11.2"
@@ -2057,6 +2154,7 @@
 		},
 		"node_modules/esprima": {
 			"version": "4.0.1",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"bin": {
 				"esparse": "bin/esparse.js",
@@ -2108,6 +2206,7 @@
 		},
 		"node_modules/etag": {
 			"version": "1.8.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -2115,6 +2214,7 @@
 		},
 		"node_modules/evaluate-value": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -2129,6 +2229,7 @@
 		},
 		"node_modules/extend-shallow": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -2144,6 +2245,7 @@
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -2158,6 +2260,7 @@
 		},
 		"node_modules/fast-glob/node_modules/glob-parent": {
 			"version": "5.1.2",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -2178,6 +2281,7 @@
 		},
 		"node_modules/fast-sort": {
 			"version": "3.4.1",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
@@ -2205,6 +2309,7 @@
 		},
 		"node_modules/fastq": {
 			"version": "1.19.0",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -2223,6 +2328,7 @@
 		},
 		"node_modules/filesize": {
 			"version": "10.1.6",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">= 10.4.0"
@@ -2230,6 +2336,7 @@
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -2240,6 +2347,7 @@
 		},
 		"node_modules/finalhandler": {
 			"version": "1.3.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "2.6.9",
@@ -2256,6 +2364,7 @@
 		},
 		"node_modules/finalhandler/node_modules/debug": {
 			"version": "2.6.9",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
@@ -2263,6 +2372,7 @@
 		},
 		"node_modules/finalhandler/node_modules/ms": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/find-up": {
@@ -2299,6 +2409,7 @@
 		},
 		"node_modules/foreground-child": {
 			"version": "3.3.1",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.6",
@@ -2313,6 +2424,7 @@
 		},
 		"node_modules/fresh": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -2320,6 +2432,7 @@
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2331,6 +2444,7 @@
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2338,6 +2452,7 @@
 		},
 		"node_modules/get-caller-file": {
 			"version": "2.0.5",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
@@ -2358,6 +2473,7 @@
 		},
 		"node_modules/glob": {
 			"version": "10.4.5",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"foreground-child": "^3.1.0",
@@ -2376,6 +2492,7 @@
 		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.3"
@@ -2388,6 +2505,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
 			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -2395,6 +2513,7 @@
 		},
 		"node_modules/glob/node_modules/minimatch": {
 			"version": "9.0.5",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
@@ -2491,10 +2610,12 @@
 		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/gray-matter": {
 			"version": "4.0.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"js-yaml": "^3.13.1",
@@ -2508,6 +2629,7 @@
 		},
 		"node_modules/gray-matter/node_modules/argparse": {
 			"version": "1.0.10",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
@@ -2515,6 +2637,7 @@
 		},
 		"node_modules/gray-matter/node_modules/js-yaml": {
 			"version": "3.14.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
@@ -2534,6 +2657,7 @@
 		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -2564,6 +2688,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
 			"integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+			"dev": true,
 			"funding": [
 				"https://github.com/fb55/htmlparser2?sponsor=1",
 				{
@@ -2582,6 +2707,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
 			"integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+			"dev": true,
 			"dependencies": {
 				"domelementtype": "^2.0.1",
 				"domhandler": "^4.2.0",
@@ -2595,6 +2721,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
 			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+			"dev": true,
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
@@ -2603,6 +2730,7 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
 			"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+			"dev": true,
 			"dependencies": {
 				"domelementtype": "^2.2.0"
 			},
@@ -2617,6 +2745,7 @@
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
 			"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+			"dev": true,
 			"dependencies": {
 				"dom-serializer": "^1.0.1",
 				"domelementtype": "^2.2.0",
@@ -2630,6 +2759,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
 			"integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.12"
 			},
@@ -2639,6 +2769,7 @@
 		},
 		"node_modules/http-equiv-refresh": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -2646,6 +2777,7 @@
 		},
 		"node_modules/http-errors": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"depd": "2.0.0",
@@ -2726,6 +2858,7 @@
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ini": {
@@ -2735,6 +2868,7 @@
 		},
 		"node_modules/is-alphabetical": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -2743,6 +2877,7 @@
 		},
 		"node_modules/is-alphanumerical": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-alphabetical": "^2.0.0",
@@ -2760,6 +2895,7 @@
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"binary-extensions": "^2.0.0"
@@ -2770,6 +2906,7 @@
 		},
 		"node_modules/is-core-module": {
 			"version": "2.16.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"hasown": "^2.0.2"
@@ -2783,6 +2920,7 @@
 		},
 		"node_modules/is-decimal": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -2791,6 +2929,7 @@
 		},
 		"node_modules/is-extendable": {
 			"version": "0.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -2798,6 +2937,7 @@
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -2818,6 +2958,7 @@
 		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -2840,10 +2981,12 @@
 		"node_modules/is-json": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-			"integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA=="
+			"integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
+			"dev": true
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -2859,10 +3002,12 @@
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/iso-639-1": {
 			"version": "3.1.5",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0"
@@ -2870,6 +3015,7 @@
 		},
 		"node_modules/jackspeak": {
 			"version": "3.4.3",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
@@ -2883,6 +3029,7 @@
 		},
 		"node_modules/jiti": {
 			"version": "1.21.7",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"jiti": "bin/jiti.js"
@@ -2895,6 +3042,7 @@
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -2932,6 +3080,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
 			"integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2973,6 +3122,7 @@
 		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -2980,6 +3130,7 @@
 		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -3006,6 +3157,7 @@
 		},
 		"node_modules/lilconfig": {
 			"version": "3.1.3",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14"
@@ -3016,10 +3168,12 @@
 		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/linkify-it": {
 			"version": "5.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"uc.micro": "^2.0.0"
@@ -3030,6 +3184,7 @@
 			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.2.tgz",
 			"integrity": "sha512-sQKw2Si2g9KUZNY3XNvRuDq4UJqpHwF0/FQzZR2M7I5MvtpWvibikCjUVJzZdGE0ByurEl3KQNvsGetd1ty1/Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"chalk": "^5.4.1",
 				"commander": "^14.0.0",
@@ -3067,6 +3222,7 @@
 			"version": "10.21.1",
 			"resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.21.1.tgz",
 			"integrity": "sha512-NZXmCwv3RG5nire3fmIn9HsOyJX3vo+ptp0yaXUHAMzSNBhx74Hm+dAGJvscUA6lNqbLuYfXgNavRQ9UbUJhQQ==",
+			"dev": true,
 			"dependencies": {
 				"commander": "^10.0.0"
 			},
@@ -3086,12 +3242,14 @@
 			"version": "10.0.1",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
 			"integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+			"dev": true,
 			"engines": {
 				"node": ">=14"
 			}
 		},
 		"node_modules/list-to-array": {
 			"version": "1.1.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/listr2": {
@@ -3135,6 +3293,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
 			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
@@ -3151,6 +3310,7 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/log-update": {
@@ -3221,10 +3381,12 @@
 		},
 		"node_modules/lru-cache": {
 			"version": "10.4.3",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/luxon": {
 			"version": "3.6.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -3232,6 +3394,7 @@
 		},
 		"node_modules/markdown-it": {
 			"version": "14.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1",
@@ -3317,6 +3480,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
 			"integrity": "sha512-9ORVtDUFk4u/NFfo0vG/ND/z7UQCVZBL539YW0+U1I7H1BkZwizcPx5foFv7LCPcBnm2U6RjFnQOsIvN4/Vm2A==",
+			"dev": true,
 			"dependencies": {
 				"array-differ": "^1.0.0",
 				"array-union": "^1.0.1",
@@ -3331,6 +3495,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+			"dev": true,
 			"dependencies": {
 				"array-uniq": "^1.0.1"
 			},
@@ -3340,10 +3505,12 @@
 		},
 		"node_modules/mdn-data": {
 			"version": "2.12.2",
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/mdurl": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/meow": {
@@ -3359,6 +3526,7 @@
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -3902,6 +4070,7 @@
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -3913,6 +4082,7 @@
 		},
 		"node_modules/mime": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"mime": "cli.js"
@@ -3923,6 +4093,7 @@
 		},
 		"node_modules/mime-db": {
 			"version": "1.54.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -3930,6 +4101,7 @@
 		},
 		"node_modules/mime-types": {
 			"version": "3.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mime-db": "^1.54.0"
@@ -3953,6 +4125,7 @@
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -3963,6 +4136,7 @@
 		},
 		"node_modules/minimist": {
 			"version": "1.2.8",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3970,6 +4144,7 @@
 		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -3977,18 +4152,22 @@
 		},
 		"node_modules/moo": {
 			"version": "0.5.2",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/morphdom": {
 			"version": "2.7.5",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ms": {
 			"version": "2.1.3",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/mz": {
 			"version": "2.7.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0",
@@ -4010,6 +4189,7 @@
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.8",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4033,10 +4213,12 @@
 			"version": "2.0.19",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
 			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/node-retrieve-globals": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"acorn": "^8.14.1",
@@ -4046,6 +4228,7 @@
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4055,6 +4238,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
 			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"boolbase": "^1.0.0"
@@ -4065,6 +4249,7 @@
 		},
 		"node_modules/nunjucks": {
 			"version": "3.2.4",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"a-sync-waterfall": "^1.0.0",
@@ -4088,6 +4273,7 @@
 		},
 		"node_modules/nunjucks/node_modules/commander": {
 			"version": "5.1.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -4095,6 +4281,7 @@
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4102,6 +4289,7 @@
 		},
 		"node_modules/object-hash": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -4109,6 +4297,7 @@
 		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ee-first": "1.1.1"
@@ -4179,6 +4368,7 @@
 		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
+			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/parent-module": {
@@ -4231,10 +4421,12 @@
 		},
 		"node_modules/parse-srcset": {
 			"version": "1.0.2",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -4250,6 +4442,7 @@
 		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4257,10 +4450,12 @@
 		},
 		"node_modules/path-parse": {
 			"version": "1.0.7",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/path-scurry": {
 			"version": "1.11.1",
+			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^10.2.0",
@@ -4288,10 +4483,12 @@
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -4313,6 +4510,7 @@
 		},
 		"node_modules/pify": {
 			"version": "2.3.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4320,6 +4518,7 @@
 		},
 		"node_modules/pirates": {
 			"version": "4.0.7",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -4327,6 +4526,7 @@
 		},
 		"node_modules/please-upgrade-node": {
 			"version": "3.2.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"semver-compare": "^1.0.0"
@@ -4336,6 +4536,7 @@
 			"version": "8.5.3",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
 			"integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4364,6 +4565,7 @@
 			"version": "10.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
 			"integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^7.0.0",
@@ -4380,6 +4582,7 @@
 			"version": "11.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-11.0.1.tgz",
 			"integrity": "sha512-0UnkNPSayHKRe/tc2YGW6XnSqqOA9eqpiRMgRlV1S6HdGi16vwJBx7lviARzbV1HpQHqLLRH3o8vTcB0cLc+5g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^3.3.0",
@@ -4406,6 +4609,7 @@
 		},
 		"node_modules/postcss-cli/node_modules/fs-extra": {
 			"version": "11.3.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
@@ -4418,6 +4622,7 @@
 		},
 		"node_modules/postcss-cli/node_modules/jsonfile": {
 			"version": "6.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"universalify": "^2.0.0"
@@ -4430,6 +4635,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.1.0.tgz",
 			"integrity": "sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4467,6 +4673,7 @@
 		},
 		"node_modules/postcss-cli/node_modules/universalify": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
@@ -4476,6 +4683,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.4.tgz",
 			"integrity": "sha512-ziQuVzQZBROpKpfeDwmrG+Vvlr0YWmY/ZAk99XD+mGEBuEojoFekL41NCsdhyNUtZI7DPOoIWIR7vQQK9xwluw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.25.1",
@@ -4494,6 +4702,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.6.tgz",
 			"integrity": "sha512-MD/eb39Mr60hvgrqpXsgbiqluawYg/8K4nKsqRsuDX9f+xN1j6awZCUv/5tLH8ak3vYp/EMXwdcnXvfZYiejCQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.25.1",
@@ -4510,6 +4719,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.4.tgz",
 			"integrity": "sha512-6tCUoql/ipWwKtVP/xYiFf1U9QgJ0PUvxN7pTcsQ8Ns3Fnwq1pU5D5s1MhT/XySeLq6GXNvn37U46Ded0TckWg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^7.1.0"
@@ -4525,6 +4735,7 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.2.tgz",
 			"integrity": "sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4537,6 +4748,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.1.tgz",
 			"integrity": "sha512-cFrJKZvcg/uxB6Ijr4l6qmn3pXQBna9zyrPC+sK0zjbkDUZew+6xDltSF7OeB7rAtzaaMVYSdbod+sZOCWnMOg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4549,6 +4761,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.1.tgz",
 			"integrity": "sha512-7c3MMjjSZ/qYrx3uc1940GSOzN1Iqjtlqe8uoSg+qdVPYyRb0TILSqqmtlSFuE4mTDECwsm397Ya7iXGzfF7lg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4561,6 +4774,7 @@
 			"version": "16.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
 			"integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.0.0",
@@ -4576,6 +4790,7 @@
 		},
 		"node_modules/postcss-import-ext-glob": {
 			"version": "2.1.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-glob": "^3.2.12",
@@ -4588,6 +4803,7 @@
 		},
 		"node_modules/postcss-js": {
 			"version": "4.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"camelcase-css": "^2.0.1"
@@ -4605,6 +4821,7 @@
 		},
 		"node_modules/postcss-load-config": {
 			"version": "4.0.2",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4640,6 +4857,7 @@
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.5.tgz",
 			"integrity": "sha512-Kpu5v4Ys6QI59FxmxtNB/iHUVDn9Y9sYw66D6+SZoIk4QTz1prC4aYkhIESu+ieG1iylod1f8MILMs1Em3mmIw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
@@ -4656,6 +4874,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.6.tgz",
 			"integrity": "sha512-2jIPT4Tzs8K87tvgCpSukRQ2jjd+hH6Bb8rEEOUDmmhOeTcqDg5fEFK8uKIu+Pvc3//sm3Uu6FRqfyv7YF7+BQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.25.1",
@@ -4674,6 +4893,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.1.tgz",
 			"integrity": "sha512-2m1uiuJeTplll+tq4ENOQSzB8LRnSUChBv7oSyFLsJRtUgAAJGP6LLz0/8lkinTgxrmJSPOEhgY1bMXOQ4ZXhQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -4689,6 +4909,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.1.tgz",
 			"integrity": "sha512-X9JjaysZJwlqNkJbUDgOclyG3jZEpAMOfof6PUZjPnPrePnPG62pS17CjdM32uT1Uq1jFvNSff9l7kNbmMSL2A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"colord": "^2.9.3",
@@ -4706,6 +4927,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.4.tgz",
 			"integrity": "sha512-3OqqUddfH8c2e7M35W6zIwv7jssM/3miF9cbCSb1iJiWvtguQjlxZGIHK9JRmc8XAKmE2PFGtHSM7g/VcW97sw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.25.1",
@@ -4723,6 +4945,7 @@
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.5.tgz",
 			"integrity": "sha512-x2/IvofHcdIrAm9Q+p06ZD1h6FPcQ32WtCRVodJLDR+WMn8EVHI1kvLxZuGKz/9EY5nAmI6lIQIrpo4tBy5+ug==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -4737,6 +4960,7 @@
 		},
 		"node_modules/postcss-nested": {
 			"version": "6.2.0",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4760,6 +4984,7 @@
 		},
 		"node_modules/postcss-nested/node_modules/postcss-selector-parser": {
 			"version": "6.1.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -4801,6 +5026,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.1.tgz",
 			"integrity": "sha512-sn413ofhSQHlZFae//m9FTOfkmiZ+YQXsbosqOWRiVQncU2BA3daX3n0VF3cG6rGLSFVc5Di/yns0dFfh8NFgQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18.12.0 || ^20.9.0 || >=22.0"
@@ -4813,6 +5039,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.1.tgz",
 			"integrity": "sha512-E5nnB26XjSYz/mGITm6JgiDpAbVuAkzXwLzRZtts19jHDUBFxZ0BkXAehy0uimrOjYJbocby4FVswA/5noOxrQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -4828,6 +5055,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.1.tgz",
 			"integrity": "sha512-pB/SzrIP2l50ZIYu+yQZyMNmnAcwyYb9R1fVWPRxm4zcUFCY2ign7rcntGFuMXDdd9L2pPNUgoODDk91PzRZuQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -4843,6 +5071,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.1.tgz",
 			"integrity": "sha512-NsSQJ8zj8TIDiF0ig44Byo3Jk9e4gNt9x2VIlJudnQQ5DhWAHJPF4Tr1ITwyHio2BUi/I6Iv0HRO7beHYOloYQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -4858,6 +5087,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.1.tgz",
 			"integrity": "sha512-QByrI7hAhsoze992kpbMlJSbZ8FuCEc1OT9EFbZ6HldXNpsdpZr+YXC5di3UEv0+jeZlHbZcoCADgb7a+lPmmQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -4873,6 +5103,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.1.tgz",
 			"integrity": "sha512-bHifyuuSNdKKsnNJ0s8fmfLMlvsQwYVxIoUBnowIVl2ZAdrkYQNGVB4RxjfpvkMjipqvbz0u7feBZybkl/6NJg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -4888,6 +5119,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.4.tgz",
 			"integrity": "sha512-LvIURTi1sQoZqj8mEIE8R15yvM+OhbR1avynMtI9bUzj5gGKR/gfZFd8O7VMj0QgJaIFzxDwxGl/ASMYAkqO8g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.25.1",
@@ -4904,6 +5136,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.1.tgz",
 			"integrity": "sha512-sUcD2cWtyK1AOL/82Fwy1aIVm/wwj5SdZkgZ3QiUzSzQQofrbq15jWJ3BA7Z+yVRwamCjJgZJN0I9IS7c6tgeQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -4919,6 +5152,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.1.tgz",
 			"integrity": "sha512-vsbgFHMFQrJBJKrUFJNZ2pgBeBkC2IvvoHjz1to0/0Xk7sII24T0qFOiJzG6Fu3zJoq/0yI4rKWi7WhApW+EFA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -4934,6 +5168,7 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.2.tgz",
 			"integrity": "sha512-AMJjt1ECBffF7CEON/Y0rekRLS6KsePU6PRP08UqYW4UGFRnTXNrByUzYK1h8AC7UWTZdQ9O3Oq9kFIhm0SFEw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssnano-utils": "^5.0.1",
@@ -4950,6 +5185,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.4.tgz",
 			"integrity": "sha512-rdIC9IlMBn7zJo6puim58Xd++0HdbvHeHaPgXsimMfG1ijC5A9ULvNLSE0rUKVJOvNMcwewW4Ga21ngyJjY/+Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.25.1",
@@ -4966,6 +5202,7 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.1.tgz",
 			"integrity": "sha512-MhyEbfrm+Mlp/36hvZ9mT9DaO7dbncU0CvWI8V93LRkY6IYlu38OPg3FObnuKTUxJ4qA8HpurdQOo5CyqqO76g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0"
@@ -4979,6 +5216,7 @@
 		},
 		"node_modules/postcss-reporter": {
 			"version": "7.1.0",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5033,6 +5271,7 @@
 		},
 		"node_modules/postcss-selector-parser": {
 			"version": "7.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -5056,6 +5295,7 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.0.tgz",
 			"integrity": "sha512-KnAlfmhtoLz6IuU3Sij2ycusNs4jPW+QoFE5kuuUOK8awR6tMxZQrs5Ey3BUz7nFCzT3eqyFgqkyrHiaU2xx3w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
@@ -5072,6 +5312,7 @@
 			"version": "7.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.4.tgz",
 			"integrity": "sha512-pmlZjsmEAG7cHd7uK3ZiNSW6otSZ13RHuZ/4cDN/bVglS5EpF2r2oxY99SuOHa8m7AWoBCelTS3JPpzsIs8skQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-selector-parser": "^7.1.0"
@@ -5085,12 +5326,14 @@
 		},
 		"node_modules/postcss-value-parser": {
 			"version": "4.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/posthtml": {
 			"version": "0.16.6",
 			"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
 			"integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
+			"dev": true,
 			"dependencies": {
 				"posthtml-parser": "^0.11.0",
 				"posthtml-render": "^3.0.0"
@@ -5103,6 +5346,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/posthtml-match-helper/-/posthtml-match-helper-2.0.3.tgz",
 			"integrity": "sha512-p9oJgTdMF2dyd7WE54QI1LvpBIkNkbSiiECKezNnDVYhGhD1AaOnAkw0Uh0y5TW+OHO8iBdSqnd8Wkpb6iUqmw==",
+			"dev": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -5114,6 +5358,7 @@
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
 			"integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+			"dev": true,
 			"dependencies": {
 				"htmlparser2": "^7.1.1"
 			},
@@ -5125,6 +5370,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
 			"integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+			"dev": true,
 			"dependencies": {
 				"is-json": "^2.0.1"
 			},
@@ -5158,6 +5404,7 @@
 		},
 		"node_modules/pretty-hrtime": {
 			"version": "1.0.3",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -5166,7 +5413,8 @@
 		"node_modules/prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw=="
+			"integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+			"dev": true
 		},
 		"node_modules/punycode": {
 			"version": "2.3.1",
@@ -5178,6 +5426,7 @@
 		},
 		"node_modules/punycode.js": {
 			"version": "2.3.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -5185,6 +5434,7 @@
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5203,6 +5453,7 @@
 		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -5210,6 +5461,7 @@
 		},
 		"node_modules/read-cache": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"pify": "^2.3.0"
@@ -5217,6 +5469,7 @@
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"picomatch": "^2.2.1"
@@ -5227,6 +5480,7 @@
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5242,6 +5496,7 @@
 		},
 		"node_modules/resolve": {
 			"version": "1.22.10",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-core-module": "^2.16.0",
@@ -5285,6 +5540,7 @@
 		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
@@ -5413,6 +5669,7 @@
 		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5444,10 +5701,12 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
 			"integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/section-matter": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"extend-shallow": "^2.0.1",
@@ -5461,6 +5720,7 @@
 			"version": "7.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
 			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -5470,10 +5730,12 @@
 		},
 		"node_modules/semver-compare": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/send": {
 			"version": "1.2.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.5",
@@ -5494,10 +5756,12 @@
 		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -5508,6 +5772,7 @@
 		},
 		"node_modules/shebang-regex": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5526,6 +5791,7 @@
 		},
 		"node_modules/signal-exit": {
 			"version": "4.1.0",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -5536,6 +5802,7 @@
 		},
 		"node_modules/slash": {
 			"version": "5.1.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
@@ -5576,6 +5843,7 @@
 		},
 		"node_modules/slugify": {
 			"version": "1.6.6",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.0.0"
@@ -5583,6 +5851,7 @@
 		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5590,6 +5859,7 @@
 		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5597,10 +5867,12 @@
 		},
 		"node_modules/sprintf-js": {
 			"version": "1.0.3",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/ssri": {
 			"version": "11.0.0",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"minipass": "^7.0.3"
@@ -5611,6 +5883,7 @@
 		},
 		"node_modules/statuses": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -5645,6 +5918,7 @@
 		"node_modules/string-width-cjs": {
 			"name": "string-width",
 			"version": "4.2.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -5657,6 +5931,7 @@
 		},
 		"node_modules/string-width-cjs/node_modules/ansi-regex": {
 			"version": "5.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5664,10 +5939,12 @@
 		},
 		"node_modules/string-width-cjs/node_modules/emoji-regex": {
 			"version": "8.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5675,6 +5952,7 @@
 		},
 		"node_modules/string-width-cjs/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -5685,6 +5963,7 @@
 		},
 		"node_modules/strip-ansi": {
 			"version": "7.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
@@ -5699,6 +5978,7 @@
 		"node_modules/strip-ansi-cjs": {
 			"name": "strip-ansi",
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -5709,6 +5989,7 @@
 		},
 		"node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
 			"version": "5.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5716,6 +5997,7 @@
 		},
 		"node_modules/strip-bom-string": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -5736,6 +6018,7 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.6.tgz",
 			"integrity": "sha512-iitguKivmsueOmTO0wmxURXBP8uqOO+zikLGZ7Mm9e/94R4w5T999Js2taS/KBOnQ/wdC3jN3vNSrkGDrlnqQg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.25.1",
@@ -6024,6 +6307,7 @@
 		},
 		"node_modules/sucrase": {
 			"version": "3.35.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -6044,6 +6328,7 @@
 		},
 		"node_modules/sucrase/node_modules/commander": {
 			"version": "4.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -6077,6 +6362,7 @@
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -6093,6 +6379,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
 			"integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"commander": "^11.1.0",
@@ -6118,6 +6405,7 @@
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
 			"integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=16"
@@ -6221,6 +6509,7 @@
 		},
 		"node_modules/tailwindcss": {
 			"version": "3.3.5",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@alloc/quick-lru": "^5.2.0",
@@ -6256,6 +6545,7 @@
 		},
 		"node_modules/tailwindcss/node_modules/lilconfig": {
 			"version": "2.1.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -6265,6 +6555,7 @@
 			"version": "15.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
 			"integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.0.0",
@@ -6280,6 +6571,7 @@
 		},
 		"node_modules/tailwindcss/node_modules/postcss-selector-parser": {
 			"version": "6.1.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -6291,10 +6583,12 @@
 		},
 		"node_modules/thenby": {
 			"version": "1.3.4",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"any-promise": "^1.0.0"
@@ -6302,6 +6596,7 @@
 		},
 		"node_modules/thenify-all": {
 			"version": "1.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"thenify": ">= 3.1.0 < 4"
@@ -6314,6 +6609,7 @@
 			"version": "0.2.14",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
 			"integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+			"dev": true,
 			"dependencies": {
 				"fdir": "^6.4.4",
 				"picomatch": "^4.0.2"
@@ -6329,6 +6625,7 @@
 			"version": "6.4.4",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
 			"integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"picomatch": "^3 || ^4"
@@ -6343,6 +6640,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
 			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -6353,6 +6651,7 @@
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -6363,6 +6662,7 @@
 		},
 		"node_modules/toidentifier": {
 			"version": "1.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.6"
@@ -6378,6 +6678,7 @@
 		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/tslib": {
@@ -6398,6 +6699,7 @@
 		},
 		"node_modules/uc.micro": {
 			"version": "2.1.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unicorn-magic": {
@@ -6415,6 +6717,7 @@
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -6424,6 +6727,7 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
 			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6460,14 +6764,17 @@
 		},
 		"node_modules/urlpattern-polyfill": {
 			"version": "10.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -6508,6 +6815,7 @@
 		"node_modules/wrap-ansi-cjs": {
 			"name": "wrap-ansi",
 			"version": "7.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -6523,6 +6831,7 @@
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
 			"version": "5.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6530,10 +6839,12 @@
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
 			"version": "8.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6541,6 +6852,7 @@
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
 			"version": "4.2.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -6553,6 +6865,7 @@
 		},
 		"node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -6588,6 +6901,7 @@
 		},
 		"node_modules/ws": {
 			"version": "8.18.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -6607,6 +6921,7 @@
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=10"
@@ -6616,6 +6931,7 @@
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
 			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
@@ -6626,6 +6942,7 @@
 		},
 		"node_modules/yargs": {
 			"version": "17.7.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -6642,6 +6959,7 @@
 		},
 		"node_modules/yargs-parser": {
 			"version": "21.1.1",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -6649,6 +6967,7 @@
 		},
 		"node_modules/yargs/node_modules/ansi-regex": {
 			"version": "5.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6656,10 +6975,12 @@
 		},
 		"node_modules/yargs/node_modules/emoji-regex": {
 			"version": "8.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/yargs/node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6667,6 +6988,7 @@
 		},
 		"node_modules/yargs/node_modules/string-width": {
 			"version": "4.2.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -6679,6 +7001,7 @@
 		},
 		"node_modules/yargs/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -51,34 +51,32 @@
 			"prettier --write --ignore-unknown"
 		]
 	},
-	"dependencies": {
-		"@11ty/eleventy": "3.1.2",
-		"clean-css": "5.3.3",
-		"cssnano": "7.1.0",
-		"postcss": "8.5.3",
-		"postcss-cli": "11.0.1",
-		"postcss-import": "16.1.1",
-		"postcss-import-ext-glob": "2.1.1",
-		"postcss-js": "4.0.1",
-		"slugify": "1.6.6",
-		"tailwindcss": "3.3.5"
-	},
+	"dependencies": {},
 	"devDependencies": {
+		"@11ty/eleventy": "3.1.2",
 		"@eslint/js": "9.31.0",
 		"chalk": "4.1.2",
+		"clean-css": "5.3.3",
 		"concurrently": "9.1.2",
+		"cssnano": "7.1.0",
 		"eslint": "9.31.0",
 		"globals": "16.3.0",
 		"husky": "9.1.7",
 		"lint-staged": "16.1.2",
 		"markdownlint-cli2": "0.18.1",
+		"postcss-cli": "11.0.1",
+		"postcss-import": "16.1.1",
+		"postcss-import-ext-glob": "2.1.1",
+		"postcss-js": "4.0.1",
 		"postcss-nesting": "13.0.2",
 		"prettier": "3.6.2",
 		"rimraf": "6.0.1",
+		"slugify": "1.6.6",
 		"stylelint": "16.19.1",
 		"stylelint-config-recess-order": "7.1.0",
 		"stylelint-config-standard": "38.0.0",
 		"stylelint-order": "7.0.0",
-		"stylelint-plugin-defensive-css": "1.0.4"
+		"stylelint-plugin-defensive-css": "1.0.4",
+		"tailwindcss": "3.3.5"
 	}
 }


### PR DESCRIPTION
This change semantically aligns these packages with their role as build-time tools for a static site, rather than runtime dependencies. For a static site, these tools are not needed in the final production environment, which only serves the pre-built HTML/CSS/JS assets.

This improves clarity in `package.json` and potentially optimizes future `npm install --production` operations in deployment pipelines.