### PR TITLE
ci: Add cooldown and show-patched-versions to dependency review setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,9 @@ updates:
     # Override the default automatic labels ("dependencies" + "github_actions").
     labels:
       - "dependabot: github-actions"
+    # Wait a few days for new releases to "settle" to avoid fresh, potentially malicious versions.
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,3 +17,4 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           comment-summary-in-pr: always
+          show-patched-versions: true


### PR DESCRIPTION
- Add 7-day cooldown to github-actions Dependabot ecosystem.
- Add show-patched-versions to dependency review workflow.